### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ anthropic==0.5.0
 openai==0.28.1
 langchain==0.0.329
 langsmith==0.0.56
-GitPython==3.1.40
+GitPython==3.1.41
 chromadb==0.4.14
 python-dotenv==1.0.0
 lxml==4.9.3


### PR DESCRIPTION
Updates GitPython from 3.1.40 to 3.1.41 to address [CVE-2023-40590](https://github.com/advisories/GHSA-wfm5-v35h-vwf4)

3.1.41 [specifically patches this vulnerability](https://github.com/gitpython-developers/GitPython/releases/tag/3.1.41)

